### PR TITLE
Add readonly flag

### DIFF
--- a/lib/jet/daemon.js
+++ b/lib/jet/daemon.js
@@ -141,6 +141,8 @@ var createDaemon = function (options) {
 		var element = elements.get(path);
 		if (!jetAccess.hasAccess(message.method, peer, element)) {
 			throw jetUtils.invalidParams('no access');
+		} else if (element.readOnly) {
+			throw jetUtils.invalidParams(path + ' is read-only');
 		}
 		var req = {};
 		if (isDefined(message.id)) {

--- a/lib/jet/daemon/peers.js
+++ b/lib/jet/daemon/peers.js
@@ -39,7 +39,8 @@ exports.Peers = function (jsonrpc, elements) {
 		eachInstance(function (peerId, peer) {
 			if (access.hasAccess('fetch', peer, element)) {
 				peer.eachFetcher(function (fetchId, fetcher) {
-					f(peerId + fetchId, fetcher);
+					var hasSetAccess = access.hasAccess('set', peer, element);
+					f(peerId + fetchId, fetcher, hasSetAccess);
 				});
 			}
 		});

--- a/lib/jet/element.js
+++ b/lib/jet/element.js
@@ -1,60 +1,70 @@
 var jetUtils = require('./utils');
 var access = require('./daemon/access');
 
+var logError = function (err) {
+	console.log('fetcher failed:', err);
+	console.log('Trace:', err.stack);
+};
+
 var Element = function (eachPeerFetcherWithAccess, owningPeer, params) {
 	this.fetchers = {};
+	this.fetcherIsReadOnly = {};
 	this.eachFetcher = jetUtils.eachKeyValue(this.fetchers);
 	var path = this.path = params.path;
+	var lowerPath = this.lowerPath = path.toLowerCase();
 	var value = this.value = params.value;
-	this.readOnly = params.readOnly;
+	var readOnly = this.readOnly = params.readOnly;
 	this.peer = owningPeer;
 	this.access = params.access;
 
 	var fetchers = this.fetchers;
-	var lowerPath = path.toLowerCase();
+	var fetcherIsReadOnly = this.fetcherIsReadOnly;
 
-
-	eachPeerFetcherWithAccess(this, function (peerFetchId, fetcher) {
+	eachPeerFetcherWithAccess(this, function (peerFetchId, fetcher, hasSetAccess) {
 		try {
-			var mayHaveInterest = fetcher(path, lowerPath, 'add', value);
+			var isReadOnly = readOnly || !hasSetAccess;
+			var mayHaveInterest = fetcher(path, lowerPath, 'add', value, isReadOnly);
 			if (mayHaveInterest) {
 				fetchers[peerFetchId] = fetcher;
+				fetcherIsReadOnly[peerFetchId] = isReadOnly;
 			}
 		} catch (err) {
-			console.error('fetcher failed', err);
+			logError(err);
 		}
 	});
 };
 
 Element.prototype._publish = function (event) {
-	var lowerPath = this.path.toLowerCase();
+	var lowerPath = this.lowerPath;
 	var value = this.value;
 	var path = this.path;
-	this.eachFetcher(function (_, fetcher) {
+	var isReadOnly = this.fetcherIsReadOnly;
+	this.eachFetcher(function (id, fetcher) {
 		try {
-			fetcher(path, lowerPath, event, value);
+			fetcher(path, lowerPath, event, value, isReadOnly[id]);
 		} catch (err) {
-			console.error('fetcher failed', err);
+			logError(err);
 		}
 	});
 };
 
 Element.prototype.change = function (value) {
 	this.value = value;
-	this._publish('change', value);
-
+	this._publish('change');
 };
 
 Element.prototype.remove = function () {
 	this._publish('remove');
 };
 
-Element.prototype.addFetcher = function (id, fetcher) {
+Element.prototype.addFetcher = function (id, fetcher, isReadOnly) {
 	this.fetchers[id] = fetcher;
+	this.fetcherIsReadOnly[id] = isReadOnly;
 };
 
 Element.prototype.removeFetcher = function (id) {
 	delete this.fetchers[id];
+	delete this.fetcherIsReadOnly[id];
 };
 
 var Elements = function () {
@@ -125,17 +135,19 @@ Elements.prototype.addFetcher = function (id, fetcher, peer) {
 		if (access.hasAccess('fetch', peer, element)) {
 			var mayHaveInterest;
 			try {
+				var isReadOnly = element.readOnly || !access.hasAccess('set', peer, element);
 				mayHaveInterest = fetcher(
 					path,
 					path.toLowerCase(),
 					'add',
-					element.value
+					element.value,
+					isReadOnly
 				);
 				if (mayHaveInterest) {
-					element.addFetcher(id, fetcher);
+					element.addFetcher(id, fetcher, isReadOnly);
 				}
 			} catch (err) {
-				console.error('fetcher failed', err);
+				logError(err);
 			}
 		}
 	});

--- a/lib/jet/element.js
+++ b/lib/jet/element.js
@@ -1,16 +1,18 @@
 var jetUtils = require('./utils');
 var access = require('./daemon/access');
 
-var Element = function (eachPeerFetcherWithAccess, owningPeer, path, value, access) {
+var Element = function (eachPeerFetcherWithAccess, owningPeer, params) {
 	this.fetchers = {};
 	this.eachFetcher = jetUtils.eachKeyValue(this.fetchers);
-	this.path = path;
-	this.value = value;
+	var path = this.path = params.path;
+	var value = this.value = params.value;
+	this.readOnly = params.readOnly;
 	this.peer = owningPeer;
-	this.access = access;
+	this.access = params.access;
 
 	var fetchers = this.fetchers;
 	var lowerPath = path.toLowerCase();
+
 
 	eachPeerFetcherWithAccess(this, function (peerFetchId, fetcher) {
 		try {
@@ -60,13 +62,14 @@ var Elements = function () {
 	this.each = jetUtils.eachKeyValue(this.instances);
 };
 
-Elements.prototype.add = function (peers, owningPeer, path, value, access) {
+Elements.prototype.add = function (peers, owningPeer, params) {
+	var path = params.path;
 	if (this.instances[path]) {
 		throw jetUtils.invalidParams({
 			pathAlreadyExists: path
 		});
 	} else {
-		this.instances[path] = new Element(peers, owningPeer, path, value, access);
+		this.instances[path] = new Element(peers, owningPeer, params);
 	}
 };
 

--- a/lib/jet/fetch-common.js
+++ b/lib/jet/fetch-common.js
@@ -54,10 +54,7 @@ exports.unfetchCore = function (peer, elements, params) {
 };
 
 exports.addCore = function (peer, eachPeerFetcher, elements, params) {
-	var path = checked(params, 'path', 'string');
-	var access = optional(params, 'access', 'object');
-	var value = params.value;
-	elements.add(eachPeerFetcher, peer, path, value, access);
+	elements.add(eachPeerFetcher, peer, params);
 };
 
 exports.removeCore = function (peer, elements, params) {

--- a/lib/jet/fetcher.js
+++ b/lib/jet/fetcher.js
@@ -10,7 +10,7 @@ exports.create = function (options, notify) {
 	var valueMatcher = jetValueMatcher.create(options);
 	var added = {};
 
-	var matchValue = function (path, event, value) {
+	var matchValue = function (path, event, value, readOnly) {
 		var isAdded = added[path];
 		if (event === 'remove' || !valueMatcher(value)) {
 			if (isAdded) {
@@ -23,51 +23,61 @@ exports.create = function (options, notify) {
 			}
 			return true;
 		}
+		var notification = {};
 		if (!isAdded) {
 			event = 'add';
+			if (readOnly) {
+				notification.readOnly = true;
+			}
 			added[path] = true;
 		} else {
 			event = 'change';
 		}
-		notify({
-			path: path,
-			event: event,
-			value: value
-		});
+		notification.path = path;
+		notification.event = event;
+		notification.value = value;
+
+		notify(notification);
 		return true;
 	};
 
 	if (isDefined(pathMatcher) && !isDefined(valueMatcher)) {
-		return function (path, lowerPath, event, value) {
+		return function (path, lowerPath, event, value, readOnly) {
 			if (!pathMatcher(path, lowerPath)) {
 				// return false to indicate no further interest.
 				return false;
 			}
-			notify({
-				path: path,
-				event: event,
-				value: value
-			});
+			var notification = {};
+			if (event == 'add' && readOnly) {
+				notification.readOnly = true;
+			}
+			notification.path = path;
+			notification.event = event;
+			notification.value = value;
+			notify(notification);
 			return true;
 		};
 	} else if (!isDefined(pathMatcher) && isDefined(valueMatcher)) {
-		return function (path, lowerPath, event, value) {
-			return matchValue(path, event, value);
+		return function (path, lowerPath, event, value, readOnly) {
+			return matchValue(path, event, value, readOnly);
 		};
 	} else if (isDefined(pathMatcher) && isDefined(valueMatcher)) {
-		return function (path, lowerPath, event, value) {
+		return function (path, lowerPath, event, value, readOnly) {
 			if (!pathMatcher(path, lowerPath)) {
 				return false;
 			}
-			return matchValue(path, event, value);
+			return matchValue(path, event, value, readOnly);
 		};
 	} else {
-		return function (path, lowerPath, event, value) {
-			notify({
-				path: path,
-				event: event,
-				value: value
-			});
+		return function (path, lowerPath, event, value, readOnly) {
+			var notification = {};
+			if (event == 'add' && readOnly) {
+				notification.readOnly = true;
+			}
+			notification.path = path;
+			notification.event = event;
+			notification.value = value;
+			notify(notification);
 			return true;
 		};
 	}

--- a/lib/jet/peer/state.js
+++ b/lib/jet/peer/state.js
@@ -9,6 +9,7 @@ var isDef = jetUtils.isDefined;
 var isArr = util.isArray;
 var invalidParams = jetUtils.invalidParams;
 var errorObject = jetUtils.errorObject;
+var noop = function() {};
 
 /**
  * State
@@ -18,6 +19,7 @@ var State = function (path, initialValue, access) {
 	this._path = path;
 	this._value = initialValue;
 	this._access = access;
+	this._dispatcher = noop;
 	var that = this;
 	this._isAddedPromise = new Bluebird(function (resolve, reject) {
 		that._isAddedPromiseResolve = resolve;
@@ -162,7 +164,7 @@ State.prototype.add = function () {
 		value: this._value,
 		access: this._access
 	};
-	if (!isDef(this._dispatcher)) {
+	if (this._dispatcher === noop) {
 		params.readOnly = true;
 	}
 	return this.connectPromise.then(function () {

--- a/lib/jet/peer/state.js
+++ b/lib/jet/peer/state.js
@@ -18,7 +18,6 @@ var State = function (path, initialValue, access) {
 	this._path = path;
 	this._value = initialValue;
 	this._access = access;
-	this._dispatcher = this.createReadOnlyDispatcher();
 	var that = this;
 	this._isAddedPromise = new Bluebird(function (resolve, reject) {
 		that._isAddedPromiseResolve = resolve;
@@ -147,21 +146,6 @@ State.prototype.createAsyncDispatcher = function (cb) {
 	return dispatch;
 };
 
-State.prototype.createReadOnlyDispatcher = function () {
-	var that = this;
-	var dispatch = function (message) {
-		var mid = message.id;
-		/* istanbul ignore else */
-		if (isDef(mid)) {
-			that.jsonrpc.queue({
-				id: mid,
-				error: invalidParams(that._path + ' is read-only')
-			});
-		}
-	};
-	return dispatch;
-};
-
 State.prototype.add = function () {
 	var that = this;
 	var addDispatcher = function (success) {
@@ -178,6 +162,9 @@ State.prototype.add = function () {
 		value: this._value,
 		access: this._access
 	};
+	if (!isDef(this._dispatcher)) {
+		params.readOnly = true;
+	}
 	return this.connectPromise.then(function () {
 		return that.jsonrpc.service('add', params, addDispatcher);
 	});

--- a/lib/jet/peer/state.js
+++ b/lib/jet/peer/state.js
@@ -9,7 +9,7 @@ var isDef = jetUtils.isDefined;
 var isArr = util.isArray;
 var invalidParams = jetUtils.invalidParams;
 var errorObject = jetUtils.errorObject;
-var noop = function() {};
+var noop = function () {};
 
 /**
  * State

--- a/lib/jet/sorter.js
+++ b/lib/jet/sorter.js
@@ -146,7 +146,7 @@ exports.create = function (options, notify) {
 					value: value,
 					index: newIndex
 				};
-				if (notification.readOnly) {
+				if (matches[newIndex - 1].readOnly) {
 					change.readOnly = true;
 				}
 				notify({

--- a/lib/jet/sorter.js
+++ b/lib/jet/sorter.js
@@ -94,10 +94,14 @@ exports.create = function (options, notify) {
 			if (isDefined(index[path])) {
 				return;
 			}
-			matches.push({
+			var match = {
 				path: path,
 				value: value
-			});
+			};
+			if (notification.readOnly) {
+				match.readOnly = true;
+			}
+			matches.push(match);
 			index[path] = matches.length;
 			return;
 		}
@@ -112,10 +116,14 @@ exports.create = function (options, notify) {
 		} else if (isDefined(lastIndex)) {
 			matches[lastIndex - 1].value = value;
 		} else {
-			matches.push({
+			var match = {
 				path: path,
 				value: value
-			});
+			};
+			if (notification.readOnly) {
+				match.readOnly = true;
+			}
+			matches.push(match)
 		}
 
 
@@ -133,13 +141,17 @@ exports.create = function (options, notify) {
 
 		if (isDefined(lastIndex) && isDefined(newIndex) && newIndex === lastIndex && isInRange(newIndex)) {
 			if (event === 'change') {
+				var change = {
+					path: path,
+					value: value,
+					index: newIndex
+				};
+				if (notification.readOnly) {
+					change.readOnly = true;
+				}
 				notify({
 					n: n,
-					changes: [{
-						path: path,
-						value: value,
-						index: newIndex,
-                        }]
+					changes: [change]
 				});
 			}
 			return;
@@ -167,11 +179,15 @@ exports.create = function (options, notify) {
 			news = matches[ji];
 			olds = sorted[ji];
 			if (news && news !== olds) {
-				changes.push({
+				var change = {
 					path: news.path,
 					value: news.value,
 					index: i
-				});
+				};
+				if (news.readOnly) {
+					change.readOnly = true;
+				}
+				changes.push(change);
 			}
 			sorted[ji] = news;
 			if (news === undefined) {

--- a/test/authentication-tests.js
+++ b/test/authentication-tests.js
@@ -282,6 +282,42 @@ describe('access tests', function () {
 		});
 	});
 
+	it('John Doe can fetch the pub-admin state which is marked readOnly (for him)', function (done) {
+		consumer = new jet.Peer({
+			url: url,
+			user: 'John Doe',
+			password: '12345'
+		});
+
+		var fetcher = new jet.Fetcher()
+			.path('equals', 'pub-admin')
+			.on('data', function (data) {
+				expect(data.path).to.equal('pub-admin');
+				expect(data.readOnly).to.be.true;
+				done();
+			});
+
+		consumer.fetch(fetcher);
+	});
+
+	it('Linus can fetch the pub-admin state which is NOT marked readOnly (for him)', function (done) {
+		consumer = new jet.Peer({
+			url: url,
+			user: 'Linus',
+			password: '12345'
+		});
+
+		var fetcher = new jet.Fetcher()
+			.path('equals', 'pub-admin')
+			.on('data', function (data) {
+				expect(data.path).to.equal('pub-admin');
+				expect(!data.readOnly).to.be.true;
+				done();
+			});
+
+		consumer.fetch(fetcher);
+	});
+
 	it('Linus can call the square method', function (done) {
 		consumer = new jet.Peer({
 			url: url,

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -25,7 +25,12 @@ describe('The jet.element module', function () {
 
 
 	it('elements.add', function () {
-		elements.add(fetchIterator, fakePeer, 'asd', 123);
+		var state = {
+			path: 'asd',
+			value: 123,
+			readOnly: true
+		};
+		elements.add(fetchIterator, fakePeer, state);
 		expect(elements.get('asd')).to.be.an.instanceof(element.Element);
 	});
 

--- a/test/fetch-test.js
+++ b/test/fetch-test.js
@@ -118,12 +118,14 @@ var portBase = 4345;
 									expect(fetchSpy.calledWith({
 										path: 'abc',
 										event: 'add',
-										value: 1
+										value: 1,
+										readOnly: true
 									})).to.be.true;
 									expect(fetchSpy.calledWith({
 										path: 'aXXX',
 										event: 'add',
-										value: 3
+										value: 3,
+										readOnly: true
 									})).to.be.true;
 									expect(fetchSpy.calledWith({
 										path: 'aXXX',
@@ -160,7 +162,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
@@ -205,12 +208,14 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						expect(fetchSpy.calledWith({
 							path: 'Aa',
 							event: 'add',
-							value: 2
+							value: 2,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -257,17 +262,20 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'Aa',
 							event: 'add',
-							value: 2
+							value: 2,
+							readOnly: true
 						})).to.be.true;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						expect(fetchSpy.calledWith({
 							path: 'aXXX',
 							event: 'add',
-							value: 3
+							value: 3,
+							readOnly: true
 						})).to.be.true;
 						expect(fetchSpy.calledWith({
 							path: 'aXXX',
@@ -311,12 +319,14 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'Abcd',
 							event: 'add',
-							value: 2
+							value: 2,
+							readOnly: true
 						})).to.be.true;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -350,7 +360,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -383,7 +394,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'Abcd',
 							event: 'add',
-							value: 2
+							value: 2,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -421,12 +433,14 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'Abcd',
 							event: 'add',
-							value: 2
+							value: 2,
+							readOnly: true
 						})).to.be.true;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -469,12 +483,14 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: '1Abcd',
 							event: 'add',
-							value: 2
+							value: 2,
+							readOnly: true
 						})).to.be.true;
 						expect(fetchSpy.calledWith({
 							path: '1abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -524,7 +540,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'a',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -561,7 +578,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'a',
 							event: 'add',
-							value: 3
+							value: 3,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -598,7 +616,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'b',
 							event: 'add',
-							value: 2
+							value: 2,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -635,7 +654,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'b',
 							event: 'add',
-							value: '1'
+							value: '1',
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -710,7 +730,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'a',
 							event: 'add',
-							value: john
+							value: john,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -767,7 +788,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'a',
 							event: 'add',
-							value: john
+							value: john,
+							readOnly: true
 						})).to.be.true;
 						states[1].value({
 							name: 'Nick',
@@ -783,7 +805,8 @@ var portBase = 4345;
 							expect(fetchSpy.calledWith({
 								path: 'b',
 								event: 'add',
-								value: nick
+								value: nick,
+								readOnly: true
 							})).to.be.true;
 							fetcher.unfetch().then(function () {
 								done();
@@ -857,7 +880,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'a',
 							event: 'add',
-							value: john
+							value: john,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch().then(function () {
 							done();
@@ -915,7 +939,8 @@ var portBase = 4345;
 							expectedChanges.push({
 								path: i.toString(),
 								value: i,
-								index: i - 9
+								index: i - 9,
+								readOnly: true
 							});
 						}
 						expect(fetchSpy.callCount).to.equal(1);
@@ -956,7 +981,8 @@ var portBase = 4345;
 							expectedChanges.push({
 								path: i.toString(),
 								value: i,
-								index: i - 9
+								index: i - 9,
+								readOnly: true
 							});
 						}
 						expect(fetchSpy.callCount).to.equal(1);
@@ -997,7 +1023,8 @@ var portBase = 4345;
 							expectedChanges.push({
 								path: i.toString(),
 								value: i,
-								index: i - 9
+								index: i - 9,
+								readOnly: true
 							});
 						}
 
@@ -1014,12 +1041,14 @@ var portBase = 4345;
 								{
 									path: '112',
 									value: 123,
-									index: 3
+									index: 3,
+									readOnly: true
               },
 								{
 									path: '12',
 									value: 12,
-									index: 4
+									index: 4,
+									readOnly: true
               }
             ];
 							expect(fetchSpy.callCount).to.equal(2);
@@ -1060,7 +1089,8 @@ var portBase = 4345;
 							expectedArray.push({
 								path: i.toString(),
 								value: i,
-								index: i - 9
+								index: i - 9,
+								readOnly: true
 							});
 						}
 
@@ -1075,12 +1105,14 @@ var portBase = 4345;
 							expectedArray[1] = {
 								path: '112',
 								value: 123,
-								index: 3
+								index: 3,
+								readOnly: true
 							};
 							expectedArray[2] = {
 								path: '12',
 								value: 12,
-								index: 4
+								index: 4,
+								readOnly: true
 							};
 							expect(fetchSpy.callCount).to.equal(2);
 							expect(fetchSpy.calledWith(expectedArray)).to.be.true;
@@ -1127,7 +1159,8 @@ var portBase = 4345;
 								expectedChanges.push({
 									path: i.toString(),
 									value: i * i,
-									index: i - 9
+									index: i - 9,
+									readOnly: true
 								});
 							}
 							expect(fetchSpy.callCount).to.equal(1);
@@ -1175,7 +1208,8 @@ var portBase = 4345;
 							expectedChanges.push({
 								path: i.toString(),
 								value: i * i,
-								index: i - 9
+								index: i - 9,
+								readOnly: true
 							});
 						}
 						expect(fetchSpy.callCount).to.equal(2);
@@ -1185,7 +1219,8 @@ var portBase = 4345;
 							expectedChanges.push({
 								path: i.toString(),
 								value: i * i,
-								index: i - 10
+								index: i - 10,
+								readOnly: true
 							});
 						}
 						expect(fetchSpy.calledWith(expectedChanges, 3)).to.be.true;
@@ -1256,14 +1291,16 @@ var portBase = 4345;
 								value: {
 									age: 2
 								},
-								index: 2
+								index: 2,
+								readOnly: true
 							});
 							expectedChanges.push({
 								path: 'aaa',
 								value: {
 									age: 3
 								},
-								index: 3
+								index: 3,
+								readOnly: true
 							});
 
 							expectedChanges.push({
@@ -1271,7 +1308,8 @@ var portBase = 4345;
 								value: {
 									age: 10
 								},
-								index: 4
+								index: 4,
+								readOnly: true
 							});
 							expect(fetchSpy.callCount).to.equal(1);
 							expect(fetchSpy.calledWith(expectedChanges, 3)).to.be.true;
@@ -1288,7 +1326,8 @@ var portBase = 4345;
 									value: {
 										age: 4
 									},
-									index: 3
+									index: 3,
+									readOnly: true
 					}], 3)).to.be.true;
 
 								// change value -> change order
@@ -1303,13 +1342,15 @@ var portBase = 4345;
 										value: {
 											age: 3
 										},
-										index: 3
+										index: 3,
+										readOnly: true
           }, {
 										path: 'aaa',
 										value: {
 											age: 4
 										},
-										index: 4
+										index: 4,
+										readOnly: true
 					}], 3)).to.be.true;
 									fetcher.unfetch();
 									done();
@@ -1362,7 +1403,8 @@ var portBase = 4345;
 										age: i * i
 									}
 								},
-								index: i - 9
+								index: i - 9,
+								readOnly: true
 							});
 						}
 						expect(fetchSpy.callCount).to.equal(1);
@@ -1420,7 +1462,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch();
 						done();
@@ -1459,7 +1502,8 @@ var portBase = 4345;
 						expect(fetchSpy.calledWith({
 							path: 'abc',
 							event: 'add',
-							value: 1
+							value: 1,
+							readOnly: true
 						})).to.be.true;
 						fetcher.unfetch();
 						done();

--- a/test/peer-test.js
+++ b/test/peer-test.js
@@ -148,6 +148,7 @@ describe('Jet module', function () {
 				expect(data.path).to.equal(random);
 				expect(data.event).to.equal('add');
 				expect(data.value).to.equal(123);
+				expect(!data.readOnly).to.equal(true);
 				jet.Promise.all([
 					this.unfetch(),
 					peer.set(random, 876).then(function () {
@@ -166,12 +167,33 @@ describe('Jet module', function () {
 			]).catch(done);
 		});
 
+		it('can add and fetch and a readOnly state', function (done) {
+			var random = randomPath();
+			var state = new jet.State(random, 123);
+
+			var fetcher = new jet.Fetcher();
+			fetcher.path('contains', random);
+			fetcher.on('data', function (data) {
+				expect(data.path).to.equal(random);
+				expect(data.event).to.equal('add');
+				expect(data.value).to.equal(123);
+				expect(data.readOnly).to.equal(true);
+				done();
+			});
+
+			jet.Promise.all([
+			peer.add(state),
+			peer.fetch(fetcher)
+			]).catch(done);
+		});
+
 		it('can add a read-only state and setting it fails', function (done) {
 			var random = randomPath();
 			var state = new jet.State(random, 123);
 			peer.add(state);
 			peer.set(random, 6237).catch(function (err) {
 				expect(err).to.be.an.object;
+				expect(err.data).to.equal(random + ' is read-only');
 				done();
 			});
 		});


### PR DESCRIPTION
States and Methods may have set the optional field "readOnly" to true.
States  and Methods are readOnly if the peer has no set/call access.
States are also readOnly if they have no "set" event handler registered.

```javascript
fetcher.on('data', function(data) {
  if (data.readOnly) {
    console.log(data.path + ' is readOnly');
  }
});
``` 