### PR TITLE
Improve webpack require net smoke bomb

### DIFF
--- a/lib/jet/daemon.js
+++ b/lib/jet/daemon.js
@@ -1,7 +1,6 @@
 'use strict'
 
-var webpackIgnore = {r: module['require']}
-var net = typeof window === 'undefined' && webpackIgnore.r('net')
+var net = require('./net')
 
 var uuid = require('uuid')
 var WebSocket = require('ws')

--- a/lib/jet/daemon.js
+++ b/lib/jet/daemon.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var webpackIgnore = {r: require}
+var webpackIgnore = {r: module['require']}
 var net = typeof window === 'undefined' && webpackIgnore.r('net')
 
 var uuid = require('uuid')

--- a/lib/jet/daemon/peers.js
+++ b/lib/jet/daemon/peers.js
@@ -2,8 +2,7 @@
 
 var jetUtils = require('../utils')
 var access = require('./access')
-var webpackIgnore = {r: module['require']}
-var net = typeof window === 'undefined' ? webpackIgnore.r('net') : {Socket: function () {}}
+var net = require('../net')
 var uuid = require('uuid')
 var EventEmitter = require('events').EventEmitter
 

--- a/lib/jet/daemon/peers.js
+++ b/lib/jet/daemon/peers.js
@@ -2,7 +2,7 @@
 
 var jetUtils = require('../utils')
 var access = require('./access')
-var webpackIgnore = {r: require}
+var webpackIgnore = {r: module['require']}
 var net = typeof window === 'undefined' ? webpackIgnore.r('net') : {Socket: function () {}}
 var uuid = require('uuid')
 var EventEmitter = require('events').EventEmitter

--- a/lib/jet/message-socket.js
+++ b/lib/jet/message-socket.js
@@ -2,8 +2,7 @@
 
 var util = require('util')
 var events = require('events')
-var webpackIgnore = {r: module['require']}
-var net = typeof window === 'undefined' && webpackIgnore.r('net')
+var net = require('./net')
 
 /**
  * MessageSocket constructor function.

--- a/lib/jet/message-socket.js
+++ b/lib/jet/message-socket.js
@@ -2,7 +2,7 @@
 
 var util = require('util')
 var events = require('events')
-var webpackIgnore = {r: require}
+var webpackIgnore = {r: module['require']}
 var net = typeof window === 'undefined' && webpackIgnore.r('net')
 
 /**

--- a/lib/jet/net.js
+++ b/lib/jet/net.js
@@ -1,0 +1,8 @@
+/*
+ * dirty hack to trick webpack (without config => next.js) to ignore
+ * the require('net') statements
+ */
+var webpackIgnore = {r: module['require']}
+var net = typeof window === 'undefined' && webpackIgnore.r('net')
+
+module.exports = net || {Socket: function () {}}


### PR DESCRIPTION
Webpack 1 as used in next.js needs to be tricked by "obfuscating" the `require('net')` statement (which is not available for browser).

Webpack 2 has parsing issues with the "solution" before.

This works fir webpack 1&2 without making the `node: {net: 'mock'}` entry in the webpack config.