### PR TITLE
Added additional return type tests

### DIFF
--- a/lib/jet/daemon/jsonrpc.js
+++ b/lib/jet/daemon/jsonrpc.js
@@ -19,7 +19,7 @@ var JsonRPC = function (services, router) {
         })
       }
       return
-    } else if (isDefined(message.result) || isDefined(message.error)) {
+    } else if (typeof message.result !== 'undefined' || typeof message.error !== 'undefined') {
       router.response(peer, message)
       return
     } else if (isDefined(message.id)) {

--- a/lib/jet/peer/jsonrpc.js
+++ b/lib/jet/peer/jsonrpc.js
@@ -154,7 +154,7 @@ JsonRPC.prototype._dispatchMessage = function (event) {
 JsonRPC.prototype._dispatchSingleMessage = function (message) {
   if (message.method && message.params) {
     this._dispatchRequest(message)
-  } else if (isDef(message.result) || isDef(message.error)) {
+  } else if (typeof message.result !== 'undefined' || typeof message.error !== 'undefined') {
     this._dispatchResponse(message)
   }
 }
@@ -171,7 +171,7 @@ JsonRPC.prototype._dispatchResponse = function (message) {
   /* istanbul ignore else */
   if (callbacks) {
     /* istanbul ignore else */
-    if (isDef(message.result) && callbacks.success) {
+    if (typeof message.result !== 'undefined' && callbacks.success) {
       callbacks.success(message.result)
     } else if (isDef(message.error) && callbacks.error) {
       var err = errors.createTypedError(message.error)

--- a/test/peer-test.js
+++ b/test/peer-test.js
@@ -689,7 +689,6 @@ describe('Jet module', function () {
       jet.Promise.all([
         peer.add(m),
         peer.call(path, []).then(function (result) {
-          console.log('result='+result)
           expect(result).to.equal(null)
           done()
         })

--- a/test/peer-test.js
+++ b/test/peer-test.js
@@ -679,6 +679,57 @@ describe('Jet module', function () {
       ]).catch(done)
     })
 
+    it('can add and call a method which returns null', function (done) {
+      var path = randomPath()
+      var m = new jet.Method(path)
+      m.on('call', function () {
+        return null
+      })
+
+      jet.Promise.all([
+        peer.add(m),
+        peer.call(path, []).then(function (result) {
+          console.log('result='+result)
+          expect(result).to.equal(null)
+          done()
+        })
+      ]).catch(done)
+    })
+
+    it('can add and call a method which returns 1', function (done) {
+      var path = randomPath()
+      var m = new jet.Method(path)
+      m.on('call', function () {
+        return 1
+      })
+
+      jet.Promise.all([
+        peer.add(m),
+        peer.call(path, []).then(function (result) {
+          expect(result).to.equal(1)
+          done()
+        })
+      ]).catch(done)
+    })
+
+    it('can add and call a method which returns an empty Object', function (done) {
+      var path = randomPath()
+      var m = new jet.Method(path)
+      m.on('call', function () {
+        return {}
+      })
+
+      jet.Promise.all([
+        peer.add(m),
+        peer.call(path, []).then(function (result) {
+          expect(typeof result).to.equal('object')
+          expect(result.length).to.equal(undefined)
+          expect(Object.keys(result).length).to.equal(0)
+          done()
+        })
+      ]).catch(done)
+    })
+
     it('a method call handler with no args works synchronous', function (done) {
       var path = randomPath()
       var m = new jet.Method(path)


### PR DESCRIPTION
Added additional tests, to verify if return types `1`, `null` and `{}` are supported.
Seems `null` does not work, because client does not receive it.